### PR TITLE
Corrects logout url

### DIFF
--- a/unifi.js
+++ b/unifi.js
@@ -54,7 +54,7 @@ var Controller = function(hostname, port)
    */
   _self.logout = function(cb)
   {
-    _self._request('/logout', null, null, cb);
+    _self._request('/api/logout', null, null, cb);
   };
 
   /**


### PR DESCRIPTION
/logout leads to a html page, /api/logout actually logs you out.