### PR TITLE
Sends /api/logout as POST

### DIFF
--- a/unifi.js
+++ b/unifi.js
@@ -54,7 +54,7 @@ var Controller = function(hostname, port)
    */
   _self.logout = function(cb)
   {
-    _self._request('/api/logout', null, null, cb);
+    _self._request('/api/logout', {}, null, cb);
   };
 
   /**


### PR DESCRIPTION
Forgot to add an empty object so that the request is sent as POST