### PR TITLE
Fix: '_request' async.whilst callback being called twice

### DIFF
--- a/unifi.js
+++ b/unifi.js
@@ -1094,11 +1094,6 @@ var Controller = function(hostname, port)
                           callback('ERROR: ' + reqjson);
                       });
 
-        req.on('error', function(err)
-        {
-          callback(err.message);
-        });
-
         count++;
       },
       function(err) {


### PR DESCRIPTION
Fix: '_request' async.whilst callback being called twice in case of an error (from request's callback and from the EventEmitter).