### PR TITLE
Support PUT requests

### DIFF
--- a/unifi.js
+++ b/unifi.js
@@ -1385,6 +1385,8 @@ var Controller = function(hostname, port)
           reqfunc = request.del;
         else if(method === 'POST')
           reqfunc = request.post;
+        else if(method === 'PUT')
+          reqfunc = request.put;
         else
           reqfunc = request.get;
 

--- a/unifi.js
+++ b/unifi.js
@@ -1373,7 +1373,10 @@ var Controller = function(hostname, port)
         // on the json data supplied and the overriding method
         if(json !== null)
         {
-          reqfunc = request.post;
+          if(method === 'PUT')
+            reqfunc = request.put;
+          else
+            reqfunc = request.post;
           reqjson.json = json;
         }
         else if(typeof(method) === 'undefined')


### PR DESCRIPTION
This patch just checks the method parameter in _request when json is provided and lets you send the json via PUT instead of POST. It defaults back to POST if no method is provided so it should be compatible with all existing code unless some existing code wrongly requests PUT as a method when it really wants POST.

This is a pre-requisite to the accessDevices patch that will follow and is simply being separated out to make reviewing/unit testing of the individual changes easier.