### PR TITLE
Some support for UnifiOS

### DIFF
--- a/unifi.js
+++ b/unifi.js
@@ -44,7 +44,7 @@ var Controller = function(hostname, port)
   /**
    * Login to UniFi Controller - login()
    */
-  _self.login = function(username, password, cb)
+  _self.login = function(username, password, final)
   {
     async.series([
       function(cb) {
@@ -61,9 +61,9 @@ var Controller = function(hostname, port)
         _self._request(_self._unifios ? '/api/auth/login' : '/api/login', {
           username: username,
           password: password
-        }, null, cb);
+        }, null, final);
       }
-    ], cb)
+    ])
   };
 
   /**
@@ -1412,7 +1412,7 @@ var Controller = function(hostname, port)
     var count = 0;
     var results = [];
     async.whilst(
-      function() { return count < proc_sites.length; },
+      function(callback) { return callback(null, (count < proc_sites.length)) },
       function(callback) {
         var reqfunc;
         var reqjson = {url: getbaseurl() + url.replace('<SITE>', proc_sites[count])};


### PR DESCRIPTION
Hi Jens,
Thank you for your work on node-unifi!

I've made some changes to support UnifiOS (which comes on the new Unifi Dream Machine/UDM Pro).

Running through your tests, this PR does not yet work for "getAllUsers", "getSessions", or "getAllAuthorizations" (getting a "Not Found" from the API, which in my experience can be due to a cookie problem. I've tried using a different cookie jar, making sure the TOKEN is passed with each request, etc - haven't figured it out yet!).    It does work for all other functions.

I may continue to troubleshoot those 3 functions at a later date, but as of now, this does work for the functions (getSiteStats, getClientDevices) I use in my own project: https://github.com/klinquist/unifiClientNotify


This is the project I used to figure out the differences:
https://github.com/Art-of-WiFi/UniFi-API-client