### PR TITLE
Function getAlarmsNotArchived added

### DIFF
--- a/unifi.js
+++ b/unifi.js
@@ -2434,6 +2434,16 @@ const Controller = function (hostname, port) {
   };
 
   /**
+   * List alarms not archived - list_alarms()
+   * -----------
+   *
+   * required paramater <sites>   = name or array of site names
+   */
+  _self.getAlarmsNotArchived = function (sites, cb) {
+    _self._request('/api/s/<SITE>/list/alarm?archived=false', null, sites, cb);
+  };	
+	
+  /**
    * Count alarms - count_alarms()
    * ------------
    * returns an array containing the alarm count


### PR DESCRIPTION
Perhaps would be better to rename the _self.getAlarms = function (sites, cb, archived) {...} to getAlarmsCount and change _self.getAlarms = function (sites, cb, archived) to list all non archived alarms. But this will be a breaking change.