### PR TITLE
Update axios to 1.7.4 to patch CVE-2024-39338

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
-        "axios": "1.7.2",
+        "axios": "1.7.4",
         "eventemitter2": "^6.4.9",
         "http-cookie-agent": "^6.0.5",
         "tough-cookie": "^4.1.4",
@@ -22,7 +22,7 @@
         "glob-parent": ">=6.0.2",
         "mocha": "^10.7.0",
         "pre-commit": "^1.2.2",
-        "should": "*",
+        "should": "latest",
         "xo": "~0.39.1"
       },
       "engines": {
@@ -1813,9 +1813,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "git+https://github.com/jens-maus/node-unifi.git"
   },
   "dependencies": {
-    "axios": "1.7.2",
+    "axios": "1.7.4",
     "eventemitter2": "^6.4.9",
     "http-cookie-agent": "^6.0.5",
     "tough-cookie": "^4.1.4",


### PR DESCRIPTION
This MR should patch CVE-2024-39338 found in axios <= 1.7.3 by updating to 1.7.4.

Before:
<img width="700" alt="Scherm­afbeelding 2024-08-14 om 08 25 29" src="https://github.com/user-attachments/assets/bfc108ab-f3e7-4b68-8fbc-875fbc4ada6f">

After:
<img width="549" alt="Scherm­afbeelding 2024-08-14 om 08 25 53" src="https://github.com/user-attachments/assets/f38b9748-cb27-4771-b458-350e54b602cc">
